### PR TITLE
Not rendering special characters

### DIFF
--- a/script.js
+++ b/script.js
@@ -439,7 +439,7 @@ function parseValue(snatch,closingBracket)
 				{
 				result=
 					{
-					html:parseObject(snatch).toString(),valid:!hasError
+					html:parseObject(snatch).toString().replaceAll('&','&amp;'),valid:!hasError
 				}
 			}
 			else


### PR DESCRIPTION
Currently if input：
```
{"&region": "example"}
```
the output  on the right is:
```
{
"®ion":"example"
}
```

Replace all `&` with `&amp;` to fix this problem.